### PR TITLE
Add support for client certificates in `ActiveDirectoryRealm`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
 			<artifactId>dircontextsource</artifactId>
 			<version>2.3.1</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -5,6 +5,7 @@
 
 	<body>
 		<release version="3.8.0-SNAPSHOT" date="TBD" description="TBD">
+			<action type="add" dev="michael-o" issue="3">Add support for string name types in UsernameSearchMapper</action>
 			<action type="update" dev="michael-o" issue="1">Make ActiveDirectoryRealmBase#getPassword(String) behave like Tomcat's AuthenticatedUserRealm#getPassword(String)</action>
 			<action type="fix" dev="michael-o">Fix possible ReferralException/PartialResultException in duplicate user check</action>
 		</release>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -5,6 +5,7 @@
 
 	<body>
 		<release version="3.8.0-SNAPSHOT" date="TBD" description="TBD">
+			<action type="add" dev="michael-o" issue="3">Canonicalize all username types to KRB5_NT_PRINCIPAL string name type</action>
 			<action type="add" dev="michael-o" issue="3">Enable ActiveDirectoryRealm to search by X.509 user certificates</action>
 			<action type="add" dev="michael-o" issue="3">Add a minimalist X.509 SAN:otherName ASN.1 parser</action>
 			<action type="add" dev="michael-o" issue="3">Add support for string name types in UsernameSearchMapper</action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -5,6 +5,7 @@
 
 	<body>
 		<release version="3.8.0-SNAPSHOT" date="TBD" description="TBD">
+			<action type="add" dev="michael-o" issue="3">Add a minimalist X.509 SAN:otherName ASN.1 parser</action>
 			<action type="add" dev="michael-o" issue="3">Add support for string name types in UsernameSearchMapper</action>
 			<action type="update" dev="michael-o" issue="1">Make ActiveDirectoryRealmBase#getPassword(String) behave like Tomcat's AuthenticatedUserRealm#getPassword(String)</action>
 			<action type="fix" dev="michael-o">Fix possible ReferralException/PartialResultException in duplicate user check</action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -5,6 +5,7 @@
 
 	<body>
 		<release version="3.8.0-SNAPSHOT" date="TBD" description="TBD">
+			<action type="add" dev="michael-o" issue="3">Enable ActiveDirectoryRealm to search by X.509 user certificates</action>
 			<action type="add" dev="michael-o" issue="3">Add a minimalist X.509 SAN:otherName ASN.1 parser</action>
 			<action type="add" dev="michael-o" issue="3">Add support for string name types in UsernameSearchMapper</action>
 			<action type="update" dev="michael-o" issue="1">Make ActiveDirectoryRealmBase#getPassword(String) behave like Tomcat's AuthenticatedUserRealm#getPassword(String)</action>

--- a/src/main/java/net/sf/michaelo/tomcat/authenticator/GSSAuthenticatorBase.java
+++ b/src/main/java/net/sf/michaelo/tomcat/authenticator/GSSAuthenticatorBase.java
@@ -29,7 +29,7 @@ import org.ietf.jgss.GSSException;
 import org.ietf.jgss.Oid;
 
 /**
- * Base implementation for GSS-based authenticators which holds common configuration information.
+ * Base implementation for GSS-based authenticators which holds common configuration.
  * See setter methods of configuration options for this authenticator.
  */
 abstract class GSSAuthenticatorBase extends AuthenticatorBase {
@@ -110,7 +110,7 @@ abstract class GSSAuthenticatorBase extends AuthenticatorBase {
 	 * Sets whether error messages will be returned as headers.
 	 *
 	 * <p>
-	 * It is not always desired or necessary to produce an error page, e.g., non-human clients do
+	 * It is not always desired or necessary to produce an error page, e.g., non-interactive clients do
 	 * not analyze it anyway, but have to consume the response (wasted time and resources). When a
 	 * client issues a request, the server will write the error messages to either one header:
 	 * {@code Auth-Error} or {@code Server-Error}.

--- a/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryPrincipal.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryPrincipal.java
@@ -33,9 +33,8 @@ import org.ietf.jgss.GSSName;
  * <li>the GSS name,</li>
  * <li>the security identifier (SID),</li>
  * <li>an optional GSS credential for credential delegation (impersonation),</li>
- * <li>the array of security groups the user has been assigned to, stored as SID strings (the actual
- * values are queried with {@code memberOf} and retrieved from {@code objectSid} and
- * {@code sIDHistory}),</li>
+ * <li>an array of security groups the user has been assigned to, stored according to the
+ * role format configured in the realm,</li>
  * <li>and a map with additional attributes which are either a {@code String}, {@code byte[]} or a
  * {@code List} of either one.</li>
  * </ul>
@@ -124,7 +123,7 @@ public class ActiveDirectoryPrincipal implements TomcatPrincipal {
 	}
 
 	/**
-	 * Returns the sorted role SID strings of the given principal.
+	 * Returns the sorted roles of the given principal.
 	 *
 	 * @return a sorted read-only view of the roles
 	 */

--- a/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.java
@@ -73,9 +73,9 @@ import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
 
 /**
- * A realm which retrieves <em>authenticated</em> users from Active Directory.
+ * A realm which retrieves <em>already authenticated</em> users from Active Directory.
  *
- * <h2>Configuration</h2> Following options can be configured:
+ * <h2 id="configuration">Configuration</h2> Following options can be configured:
  * <ul>
  * <li>{@code dirContextSourceName}: the name of the {@link DirContextSource} in JNDI with which
  * principals will be retrieved.</li>
@@ -101,7 +101,6 @@ import org.ietf.jgss.Oid;
  * <li>{@code maxIdleTime}: the maximum amount of time in milliseconds a directory server connection
  * should remain idle before it is closed. Default value is 15 minutes.</li>
  * </ul>
- * <br>
  * <h2>Connection Pooling</h2> This realm offers a poor man's directory server connection pooling
  * which can drastically improve access performance for non-session (stateless) applications. It
  * utilizes a LIFO structure based on {@link SynchronizedStack}. No background thread is managing
@@ -111,12 +110,12 @@ import org.ietf.jgss.Oid;
  * healthy. If this query fails, the connection is closed immediately. If the amount of requested
  * connections exceeds the ones available in the pool, new ones are opened and pushed onto the pool.
  * If the pool does not accept any addtional connections they are closed immediately.
- * <br>
- * This connection pool feature has to be explicitly enabled by setting {@code connectionPoolSize}
- * to greater than zero.
+ * <p>
+ * <strong>Note:</strong> This connection pool feature has to be explicitly enabled by setting
+ * {@code connectionPoolSize} to greater than zero.
  *
- * <h2>On Usernames</h2>
- * This realm processes supplied usernames in different aspects.
+ * <h2 id="on-usernames">On Usernames</h2>
+ * This realm processes supplied usernames with different types.
  * <h3>Supported Types</h3> Only a subset of username types are accepted in contrast to
  * other realm implementations. Namely, this realm must know what type is passed to properly map
  * it into Active Directory search space with a {@link UsernameSearchMapper} implementation.
@@ -126,7 +125,9 @@ import org.ietf.jgss.Oid;
  * <li>{@link X509Certificate} by extracting the {@code SAN:otherName} field and matching for
  * MS UPN type id (1.3.6.1.4.1.311.20.2.3).</li>
  * </ul>
- * Both types represent already <em>authenticated</em> users by means of GSS-API and/or TLS.
+ * <p>
+ * <strong>Note:</strong> Both types represent <em>already authenticated</em> users by means of a
+ * GSS and/or TLScontext.
  *<h3>Canonicalization</h3>
  * This realm will always try to canonicalize a given username type to a real {@link GSSName}
  * with the string name type of {@code KRB5_NT_PRINCIPAL} (1.2.840.113554.1.2.2.1) similar to
@@ -167,7 +168,7 @@ import org.ietf.jgss.Oid;
  * <em>Why do you need to use my Active Directory DNS Locator?</em> Microsoft takes a very
  * sophisticated approach on not to rely on hostnames because servers can be provisioned and
  * decommissioned any time. Instead, they heavily rely on DNS domain names and DNS SRV records
- * at runtime. I.e., an initial or a referral URL do not contain a hostname, but only a domain
+ * at runtime. I.e., an initial or a referral URL does not contain a hostname, but only a domain
  * name. While you can connect to the service with this name, you cannot easily authenticate
  * against it with Kerberos because one cannot bind the same SPN {@code ldap/<dnsDomainName>@<REALM>},
  * e.g., {@code ldap/example.com@EXAMPLE.COM} to more than one account. If you try authenticate
@@ -188,8 +189,8 @@ import org.ietf.jgss.Oid;
  * <li>{@code ignore} with multiple {@code DirContextSources}, and create a {@link CombinedRealm}
  * with one {@code ActiveDirectoryRealm} per forest.</li>
  * </ul>
- *
- * You will then have the principal properly looked up in the Active Directory.
+ *<p>
+ * You will then have the principal properly looked up in Active Directory.
  * <p>
  * Further references:
  * <a href="https://technet.microsoft.com/en-us/library/cc759550%28v=ws.10%29.aspx">How DNS Support

--- a/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealmBase.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealmBase.java
@@ -16,6 +16,7 @@
 package net.sf.michaelo.tomcat.realm;
 
 import java.security.Principal;
+import java.security.cert.X509Certificate;
 
 import org.apache.catalina.realm.RealmBase;
 import org.apache.juli.logging.Log;
@@ -25,8 +26,8 @@ import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSName;
 
 /**
- * Base realm which is able to retrieve principals from {@link GSSName GSS names} or fully
- * established {@link GSSContext GSS contexts}.
+ * Base realm which is able to retrieve principals from {@link GSSName GSS names}, fully
+ * established {@link GSSContext GSS contexts} or {@link X509Certificate TLS client certificates}.
  */
 public abstract class ActiveDirectoryRealmBase extends RealmBase {
 

--- a/src/main/java/net/sf/michaelo/tomcat/realm/StubGSSName.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/StubGSSName.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Michael Osipov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sf.michaelo.tomcat.realm;
+
+import java.util.Objects;
+
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+
+/**
+ * Stub GSS name implementation to merely transport a name with its string name type. This class is not intended to be
+ * used in real with the {@link GSSManager}.
+ */
+public class StubGSSName implements GSSName {
+
+	private final String name;
+	private final Oid oid;
+
+	public StubGSSName(String name, Oid oid) {
+		this.name = name;
+		this.oid = oid;
+	}
+
+	@Override
+	public boolean equals(GSSName another) throws GSSException {
+		if (another instanceof StubGSSName) {
+			StubGSSName stubGssName = (StubGSSName) another;
+			return Objects.equals(name, stubGssName.name) && Objects.equals(oid, stubGssName.oid);
+		}
+
+		return false;
+	}
+
+	/**
+	 * @throws UnsupportedOperationException
+	 *             always throws because not implemented
+	 */
+	@Override
+	public GSSName canonicalize(Oid mech) throws GSSException {
+		throw new UnsupportedOperationException("method canonicalize() is not supported");
+	}
+
+	/**
+	 * @throws UnsupportedOperationException
+	 *             always throws because not implemented
+	 */
+	@Override
+	public byte[] export() throws GSSException {
+		throw new UnsupportedOperationException("method export() is not supported");
+	}
+
+	@Override
+	public Oid getStringNameType() throws GSSException {
+		return oid;
+	}
+
+	/**
+	 * @throws UnsupportedOperationException
+	 *             always throws because not implemented
+	 */
+	@Override
+	public boolean isAnonymous() {
+		throw new UnsupportedOperationException("method isAnonymous() is not supported");
+	}
+
+	/**
+	 * @throws UnsupportedOperationException
+	 *             always throws because not implemented
+	 */
+	@Override
+	public boolean isMN() {
+		throw new UnsupportedOperationException("method isNM() is not supported");
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object another) {
+		if (another instanceof GSSName)
+			try {
+				return equals((GSSName) another);
+			} catch (GSSException e) {
+				; // Ignore
+			}
+
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+
+}

--- a/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameAsn1Parser.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameAsn1Parser.java
@@ -43,7 +43,7 @@ public class OtherNameAsn1Parser {
 	};
 
 	/**
-	 * Parses a DER-encoded ASN.1 {@code SAN:otherName} field into its components:
+	 * Parses the DER-encoded ASN.1 {@code SAN:otherName} field into its components:
 	 * {@code type-id} and {@code value}.
 	 *
 	 * @param otherName a DER-encoded byte array
@@ -51,7 +51,7 @@ public class OtherNameAsn1Parser {
 	 * @throws NullPointerException        if {@code null} is passed as
 	 *                                     {@code otherName}
 	 * @throws CertificateParsingException if the DER-encoded byte array does not
-	 *                                     comply with ASN.1 defininiton
+	 *                                     comply with ASN.1 DER encoding rules
 	 */
 	public static OtherNameParseResult parse(byte[] otherName) throws CertificateParsingException {
 		Objects.requireNonNull(otherName, "otherName cannot be null");

--- a/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameAsn1Parser.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameAsn1Parser.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2021 Michael Osipov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sf.michaelo.tomcat.realm.asn1;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateParsingException;
+import java.util.Objects;
+
+/**
+ * A minimalist ASN.1 parser for X.509 {@code SAN:otherName} according to RFC
+ * 5280, section 4.2.1.6.
+ * <p>
+ * It properly takes
+ * <a href="https://bugs.openjdk.java.net/browse/JDK-6776681">JDK-6776681</a>
+ * into account and solves
+ * <a href="https://bugs.openjdk.java.net/browse/JDK-8277976">JDK-8277976</a>.
+ */
+public class OtherNameAsn1Parser {
+
+	private static byte CONTEXT_SPECIFIC_BIT = 7;
+	private static byte CONSTRUCTED_BIT = 5;
+
+	private static byte MAX_SINGLE_BYTE_LENGTH = 0x7F;
+	private static byte SEQUENCE_TAG = 0x30;
+	private static byte OID_TAG = 0x06;
+	private static byte UTF8STRING_TAG = 0x0C;
+
+	private OtherNameAsn1Parser() {
+	};
+
+	/**
+	 * Parses a DER-encoded ASN.1 {@code SAN:otherName} field into its components:
+	 * {@code type-id} and {@code value}.
+	 *
+	 * @param otherName a DER-encoded byte array
+	 * @return the parse result
+	 * @throws NullPointerException        if {@code null} is passed as
+	 *                                     {@code otherName}
+	 * @throws CertificateParsingException if the DER-encoded byte array does not
+	 *                                     comply with ASN.1 defininiton
+	 */
+	public static OtherNameParseResult parse(byte[] otherName) throws CertificateParsingException {
+		Objects.requireNonNull(otherName, "otherName cannot be null");
+
+		ByteBuffer buf = ByteBuffer.wrap(otherName);
+
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("otherName type tag not available, buffer is empty");
+
+		byte tag = buf.get();
+		if (tag != SEQUENCE_TAG)
+			throw new CertificateParsingException(
+					String.format("otherName must start with a SEQUENCE tag, but starts with 0x%02x", tag));
+
+		int seqLen = parseLength(buf);
+		if (seqLen > buf.remaining())
+			throw new CertificateParsingException(String
+					.format("SEQUENCE length (%s B) is larger than the buffer offers (%s B)", seqLen, buf.remaining()));
+
+		int limit = buf.position() + seqLen;
+		buf.limit(limit);
+
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("otherName fields not available, buffer is empty");
+
+		byte[] typeId = parseOid(buf);
+		byte[] value = parseValue(buf);
+
+		return new OtherNameParseResult(typeId, value);
+	}
+
+	/**
+	 * Parses a DER-encoded ASN.1 {@code UTF8String} to a Java string:
+	 *
+	 * @param string a DER-encoded byte array
+	 * @return the converted Java string
+	 * @throws NullPointerException        if {@code null} is passed as
+	 *                                     {@code string}
+	 * @throws CertificateParsingException if the DER-encoded byte array does not
+	 *                                     comply with ASN.1 defininiton
+	 */
+	public static String parseUtf8String(byte[] string) throws CertificateParsingException {
+		Objects.requireNonNull(string, "string cannot be null");
+
+		ByteBuffer buf = ByteBuffer.wrap(string);
+
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("string type tag not available, buffer is empty");
+
+		byte tag = buf.get();
+		if (tag != UTF8STRING_TAG)
+			throw new CertificateParsingException(
+					String.format("string must start with a UTF8String tag, but starts with 0x%02x", tag));
+
+		int strLen = parseLength(buf);
+		if (strLen > buf.remaining())
+			throw new CertificateParsingException(String.format(
+					"UTF8String length (%s B) is larger than the buffer offers (%s B)", strLen, buf.remaining()));
+
+		byte[] str = new byte[strLen];
+		buf.get(str);
+
+		return new String(str, StandardCharsets.UTF_8);
+	}
+
+	private static int parseLength(ByteBuffer buf) throws CertificateParsingException {
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("Type length not available, buffer is empty");
+
+		int typeLen = buf.get() & 0xFF;
+		if (typeLen <= MAX_SINGLE_BYTE_LENGTH)
+			return typeLen;
+
+		int n = typeLen & MAX_SINGLE_BYTE_LENGTH;
+
+		if (n == 0)
+			throw new CertificateParsingException("Indefinite type length is not supported");
+
+		if (n > 2)
+			throw new CertificateParsingException("Type length above 64 KiB ist not supported");
+
+		if (n > buf.remaining())
+			throw new CertificateParsingException(String
+					.format("Type length bytes (%s B) are larger than the buffer offers (%s B)", n, buf.remaining()));
+
+		typeLen = 0;
+		for (int i = 0; i < n; i++)
+			typeLen = (typeLen << 8) | (buf.get() & 0xFF);
+
+		return typeLen;
+	}
+
+	private static byte[] parseOid(ByteBuffer buf) throws CertificateParsingException {
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("OID type tag not available, buffer is empty");
+
+		byte tag = buf.get();
+		if (tag != OID_TAG)
+			throw new CertificateParsingException(
+					String.format("OID must start with an OBJECT IDENTIFIER tag, but is 0x%02x", tag));
+
+		int oidLen = parseLength(buf);
+		if (oidLen > buf.remaining())
+			throw new CertificateParsingException(
+					String.format("OBJECT IDENTIFIER length (%s B) is larger than the buffer offers (%s B)", oidLen,
+							buf.remaining()));
+
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("OID value not available, buffer is empty");
+
+		byte[] oid = new byte[oidLen];
+		buf.get(oid);
+
+		return oid;
+	}
+
+	private static byte[] parseValue(ByteBuffer buf) throws CertificateParsingException {
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("Value type tag not available, buffer is empty");
+
+		byte tag = buf.get();
+		if (!(((tag >> CONTEXT_SPECIFIC_BIT) & 1) != 0 && ((tag >> CONSTRUCTED_BIT) & 1) != 0))
+			throw new CertificateParsingException("Value must be explicitly encoded");
+
+		int tagNumber = tag & 0xFF;
+		tagNumber &= ~(1 << CONTEXT_SPECIFIC_BIT);
+		tagNumber &= ~(1 << CONSTRUCTED_BIT);
+
+		if (tagNumber != 0)
+			throw new CertificateParsingException("Value tag number must be 0, but is " + tagNumber);
+
+		int valLen = parseLength(buf);
+		if (valLen > buf.remaining())
+			throw new CertificateParsingException(String
+					.format("Value length (%s B) is larger than the buffer offers (%s B)", valLen, buf.remaining()));
+
+		int limit = buf.position() + valLen;
+		buf.limit(limit);
+
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("Value not available, buffer is empty");
+
+		// Workaround for https://bugs.openjdk.java.net/browse/JDK-6776681
+		int pos = buf.position();
+		tag = buf.get();
+		tagNumber = tag & 0xFF;
+		tagNumber &= ~(1 << CONTEXT_SPECIFIC_BIT);
+		tagNumber &= ~(1 << CONSTRUCTED_BIT);
+		if (((tag >> CONTEXT_SPECIFIC_BIT) & 1) != 0 && ((tag >> CONSTRUCTED_BIT) & 1) != 0 && tagNumber == 0) {
+			valLen = parseLength(buf);
+			if (valLen > buf.remaining())
+				throw new CertificateParsingException(String.format(
+						"Value length (%s B) is larger than the buffer offers (%s B)", valLen, buf.remaining()));
+
+			limit = buf.position() + valLen;
+			buf.limit(limit);
+		} else
+			buf.position(pos);
+
+		if (!buf.hasRemaining())
+			throw new CertificateParsingException("Value not available, buffer is empty");
+
+		byte[] value = new byte[valLen];
+		buf.get(value);
+
+		return value;
+	}
+
+}

--- a/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameParseResult.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameParseResult.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Michael Osipov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sf.michaelo.tomcat.realm.asn1;
+
+/**
+ * This class holds the parsing result of {@link OtherNameAsn1Parser}.
+ */
+public class OtherNameParseResult {
+
+	private byte[] typeId;
+	private byte[] value;
+
+	public OtherNameParseResult(byte[] typeId, byte[] value) {
+		this.typeId = typeId;
+		this.value = value;
+	}
+
+	/**
+	 * Returns the type id (OID).
+	 *
+	 * @return the DER-encoded type (OID) id without tag and length
+	 */
+	public byte[] getTypeId() {
+		return typeId;
+	}
+
+	/**
+	 * Returns the value.
+	 *
+	 * @return the untagged DER-encoded value
+	 */
+	public byte[] getValue() {
+		return value;
+	}
+
+}

--- a/src/main/java/net/sf/michaelo/tomcat/realm/asn1/package-info.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/asn1/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Michael Osipov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Minimalist ASN.1 parser components.
+ */
+package net.sf.michaelo.tomcat.realm.asn1;

--- a/src/main/java/net/sf/michaelo/tomcat/realm/mapper/UsernameSearchMapper.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/mapper/UsernameSearchMapper.java
@@ -25,7 +25,7 @@ import net.sf.michaelo.tomcat.realm.ActiveDirectoryRealm;
 
 /**
  * A mapper interface (strategy pattern) for translating GSS names to Active Directory search
- * parameters.
+ * space parameters.
  */
 public interface UsernameSearchMapper {
 
@@ -60,8 +60,8 @@ public interface UsernameSearchMapper {
 	boolean supportsGssName(GSSName gssName);
 
 	/**
-	 * Maps a GSS name to AD search parameters. A mapper implementation must assure that the user
-	 * can be found in the given {@code context} when an approriate GSS name is presented. The
+	 * Maps a GSS name to AD search space parameters. A mapper implementation must assure that the
+	 * user can be found in the given {@code context} when an approriate GSS name is presented. The
 	 * implementor must be aware that the returned search base might need to be relativized to the
 	 * root DN of the context.
 	 *

--- a/src/main/java/net/sf/michaelo/tomcat/realm/mapper/UsernameSearchMapper.java
+++ b/src/main/java/net/sf/michaelo/tomcat/realm/mapper/UsernameSearchMapper.java
@@ -19,6 +19,7 @@ import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 
 import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
 
 import net.sf.michaelo.tomcat.realm.ActiveDirectoryRealm;
 
@@ -43,6 +44,22 @@ public interface UsernameSearchMapper {
 	}
 
 	/**
+	 * Returns an array of name type OIDs which a mapper is able to map into AD search space.
+	 *
+	 * @return supported string name type OIDs
+	 */
+	Oid[] getSupportedStringNameTypes();
+
+
+	/**
+	 * Determines whether a mapper is able to map a given GSS name into AD search space.
+	 *
+	 * @param gssName the gssName to test
+	 * @return {@code} if this mapper is able to map a name, {@code false} otherwise
+	 */
+	boolean supportsGssName(GSSName gssName);
+
+	/**
 	 * Maps a GSS name to AD search parameters. A mapper implementation must assure that the user
 	 * can be found in the given {@code context} when an approriate GSS name is presented. The
 	 * implementor must be aware that the returned search base might need to be relativized to the
@@ -55,6 +72,8 @@ public interface UsernameSearchMapper {
 	 * @return mapped values for user retrieval
 	 * @throws NamingException
 	 *             if a context-related error has occured
+	 * @throws IllegalArgumentException
+	 *             if the GSS name is not supported
 	 */
 	MappedValues map(DirContext context, GSSName gssName) throws NamingException;
 

--- a/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
+++ b/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
@@ -48,3 +48,6 @@ activeDirectoryRealm.validate.namingException=Exception validating directory ser
 activeDirectoryRealm.release=Releasing directory server connection ''{0}'' to pool
 activeDirectoryRealm.reuse=Reusing existing directory server connection ''{0}''
 activeDirectoryRealm.exceedMaxIdleTime=Directory server connection ''{0}'' from pool exceeds max idle time, closing it
+activeDirectoryRealm.sanParsingFailed=Failed to parse subject alternative names from client certificate
+activeDirectoryRealm.processingSanOtherName=Processing SAN:otherName ''{0}'' from client certificate ''{1}''
+activeDirectoryRealm.msUpnExtracted=Successfully extracted MS UPN ''{0}'' from client certificate ''{1}''

--- a/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
+++ b/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
@@ -1,13 +1,14 @@
 activeDirectoryRealmBase.cannotGetRoles=Cannot get roles from principal ''{0}'' ({1})
 
+activeDirectoryRealm.nameTypeNotSupported=Mapper ''{0}'' does not support name type ''{1}'' of user ''{2}''
 activeDirectoryRealm.usernameSearch=Searching for username ''{0}'' in base ''{1}'' and attribute \
-''{2}'' with mapper ''{3}''
-activeDirectoryRealm.user.referralException=User search with mapper ''{0}'' wants us to continue with \
+''{2}'' from mapper ''{3}''
+activeDirectoryRealm.user.referralException=User search from mapper ''{0}'' wants us to continue with \
 ''{1}'' and follow a referral to ''{2}'', ignoring it
-activeDirectoryRealm.userNotMapped=User ''{0}'' with mapper ''{1}'' has not been mapped
-activeDirectoryRealm.user.partialResultException=User search with mapper ''{0}'' cannot be completed \
+activeDirectoryRealm.userNotFoundWithMapper=User ''{0}'' from mapper ''{1}'' has not been found
+activeDirectoryRealm.user.partialResultException=User search from mapper ''{0}'' cannot be completed \
 and wants us to continue with ''{1}'', ignoring it
-activeDirectoryRealm.userNotFound=User ''{0}'' has not been found
+activeDirectoryRealm.userNotFound=User ''{0}'' has not been found with any mapper
 activeDirectoryRealm.duplicateUser=User ''{0}'' has multiple entries
 activeDirectoryRealm.duplicateUser.referralException=Multiple user check for ''{0}'' wants us to continue with \
 ''{1}'' and follow a referral to ''{2}'', ignoring it

--- a/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
+++ b/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
@@ -51,3 +51,6 @@ activeDirectoryRealm.exceedMaxIdleTime=Directory server connection ''{0}'' from 
 activeDirectoryRealm.sanParsingFailed=Failed to parse subject alternative names from client certificate
 activeDirectoryRealm.processingSanOtherName=Processing SAN:otherName ''{0}'' from client certificate ''{1}''
 activeDirectoryRealm.msUpnExtracted=Successfully extracted MS UPN ''{0}'' from client certificate ''{1}''
+activeDirectoryRealm.canonicalizingUser=Canonicalizing user from string name type ''{0}'' to ''{1}''
+activeDirectoryRealm.canonicalizeUserFailed=Failed to canonicalize user ''{0}''
+activeDirectoryRealm.userCanonicalized=Successfully canonicalized user to ''{0}''

--- a/src/site/apt/authenticators.apt.vm
+++ b/src/site/apt/authenticators.apt.vm
@@ -26,11 +26,12 @@
 
 Choosing and Using Authenticators
 
-  Choose an authenticator which will determine a user's identity. Usually, the {{{The_SPNEGO_Authenticator}<<<SpnegoAuthenticator>>>}}
+  Choose an authenticator which will determine a user's identity. Usually, the
+  {{{SPNEGO_Authenticator}<<<SpnegoAuthenticator>>>}} or {{{SSL_Authenticator}<<<SSLAuthenticator>>>}}
   will do, but during local development you will find the {{{Using_an_Authenticator_During_Development}<<<CurrentWindowsIdentityAuthenticator>>>}}
   very handy.
 
-* The SPNEGO Authenticator
+* SPNEGO Authenticator
 
   The {{{./apidocs/net/sf/michaelo/tomcat/authenticator/SpnegoAuthenticator.html}<<<SpnegoAuthenticator>>>}}
   challenges the client to perform {{{https://tools.ietf.org/html/rfc4559}SPNEGO}} authentication. In
@@ -39,7 +40,7 @@ Choosing and Using Authenticators
 
     [Attention] Though SPNEGO is intended to negotiate a mechanism, OpenJDK currently supports
                 Kerberos 5 only and not NTLM additionally due to its proprietary nature. Anyway, it
-                is discouraged by Microsoft {{{https://serverfault.com/a/384721/116898}1}})
+                is {{{https://serverfault.com/a/384721/116898}discouraged by Microsoft}}
                 to rely on NTLM anymore.
 
   Open or create your app's <<<context.xml>>> and add:
@@ -54,18 +55,39 @@ Choosing and Using Authenticators
 </Context>
 +----------------------------
 
-  Provide the login entry name from your <<<login.conf>>> configured for the machine account
+  Provide the login entry name from your <<<login.conf>>> configured for the machine or service account
   capable of accepting GSS contexts with SPNEGO/Kerberos.
 
   You have successfully configured the <<<SpnegoAuthenticator>>> in your webapp. It is now ready to use.
 
+* SSL Authenticator
+
+  The {{{https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/authenticator/SSLAuthenticator.html}<<<SSLAuthenticator>>>}}
+  comes bundled with Tomcat and extracts user certificates from the TLS context.
+
+  Open or create your app's <<<context.xml>>> and add:
+
++----------------------------
+<Context>
+[$ellipsis]
+  <!-- Add this -->
+  <Valve className="org.apache.catalina.authenticator.SSLAuthenticator" />
+[$ellipsis]
+</Context>
++----------------------------
+
+  It is expected that you follow the Tomcat documentation to properly configure your <<<Connector>>>
+  for certificate-based authentication.
+
+  You have successfully configured the <<<SSLAuthenticator>>> in your webapp. It is now ready to use.
+
 * Using an Authenticator During Development
 
-  After examining the authenticator above and probably ask yourself: How do I use that on my local
+  After examining the authenticators above and probably ask yourself: How do I use that on my local
   development machine? {{{./apidocs/net/sf/michaelo/tomcat/authenticator/CurrentWindowsIdentityAuthenticator.html}<<<CurrentWindowsIdentityAuthenticator>>>}}
   to the rescue. It will automatically obtain the GSS credential of the currently logged in domain
   user and auto-login you in the application. This is very handy when you are running your Tomcat
-  instance inside Eclipse.
+  instance inside an IDE.
 
   Open or create your app's <<<context.xml>>> and add:
 
@@ -89,6 +111,6 @@ Choosing and Using Authenticators
   Now you have successfully configured the <<<CurrentWindowsIdentityAuthenticator>>> in your webapp.
   It is now ready to use.
 
-The Next Step
+Next Step
 
   After you have properly configured an authenticator, go on to the {{{./realms.html}realm}}.

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -36,8 +36,8 @@ About ${project.name}
   Working in a corporate environment leaves you virtually no option of not having real SSO for a
   (Java) webapp, especially when this works with Microsoft IIS with a few clicks. Unfortunately,
   the Apache Tomcat did not have anything like this out of the box for years.\
-  After a deep dive into Kerberos, GSS-API, Active Directory and LDAP in Java, I made a custom component
-  to fill that gap. Portions of this project have been {{{https://bz.apache.org/bugzilla/show_bug.cgi?id=48685}integrated}}
+  After a deep dive into Kerberos, GSS-API, TLS, PKI, Active Directory and LDAP in Java, I made a
+  custom components to fill that gap. Portions of this project have been {{{https://bz.apache.org/bugzilla/show_bug.cgi?id=48685}integrated}}
   into Apache Tomcat 7 and onwards. Though, this project covers much more than an authenticator.
 
   This library has served me very well for many years and still does a great job in a complex

--- a/src/site/apt/realms.apt.vm
+++ b/src/site/apt/realms.apt.vm
@@ -27,29 +27,29 @@
 Choosing and Using Realms
 
   After the authenticator has established a user's identity, it's time to search for it. Usually,
-  the {{{The_Active_Directory_Realm}<<<ActiveDirectoryRealm>>>}} will do, but for testing purposes you
+  the {{{Active_Directory_Realm}<<<ActiveDirectoryRealm>>>}} will do, but for testing purposes you
   will find the default {{{Using_a_Realm_for_Testing_Purposes}<<<UserDatabaseRealm>>>}} very handy.
 
     [Tip] I strongly recommend to try the {{{Using_a_Realm_for_Testing_Purposes}<<<UserDatabaseRealm>>>}}
           first, you'll see whether the authenticator works at all. If it does, go on to the
           {{{The_Active_Directory_Realm}<<<ActiveDirectoryRealm>>>}}.
 
-* The Active Directory Realm
+* Active Directory Realm
 
   The {{{./apidocs/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.html}<<<ActiveDirectoryRealm>>>}}
-  will query your Active Directory for a user by his/her
-  {{{https://docs.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#user-principal-name}implicit UPN}}
+  will query your Active Directory domain for a user by the {{{./apidocs/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.html#on-usernames}string name type of the supplied username}}
   and retrieve all the necessary information, e.g., his/her security groups.
 
-  It requires two steps of setup: First, you will need to configure a <<<DirContextSourceFactory>>>
-  with the parameters of your Active Direcory. Second, the realm itself pointing to that Active Directory.
+  It requires a two-step setup: First, you will need to configure a <<<DirContextSourceFactory>>>
+  with the parameters of your Active Directory domain. Second, the realm itself pointing to that Active
+  Directory domain.
 
 ** Configuring a Directory Context Source Factory
 
   Please read the documentation of the {{{https://michael-o.github.io/dirctxsrc/dircontextsourcefactory.html}<<<DirContextSourceFactory>>>}}
   on how to configure it in detail. Here is a minimal working configuration:
 
-    [Tip] Never rely on hard coded hostnames, use my {{{https://michael-o.github.io/activedirectory-dns-locator/}<<<ActiveDirectoryLdapDnsProvider>>>}}
+    [Tip] Never rely on hard-coded hostnames, use my {{{https://michael-o.github.io/activedirectory-dns-locator/}<<<ActiveDirectoryLdapDnsProvider>>>}}
           to auto-locate servers for Active Directory domains via DNS.
 
     []
@@ -98,17 +98,18 @@ Choosing and Using Realms
 
 ** Using Security Groups from Active Directory
 
-  By default the <<<ActiveDirectoryRealm>>> will populate all roles as SID strings for the given principal.
+  The <<<ActiveDirectoryRealm>>> will populate all roles as SID strings for the given principal by default.
   While it might not look convenient in the first place, it adds benefit when security groups are moved
   from/to other domains, the SID history is completely retained. I.e., your application will continue
   to work even with the old SID. If you would like to map SIDs to developer-friendly role names,
-  checkout the {{{http://mo-tomcat-ext.sourceforge.net/user-guide.html#PropertiesRoleMappingListener}<<<PropertiesRoleMappingListener>>>}}.
-  See extended capabilities of this realm in the {{{./apidocs/net/sf/michaelo/tomcat/realm/ActiveDirectoryPrincipal.html}Javadoc}}.
+  checkout the {{{http://mo-tomcat-ext.sourceforge.net/user-guide.html#PropertiesRoleMappingListener}<<<PropertiesRoleMappingListener>>>}}
+  or use other role formats, but the SID see extended capabilities of this realm in the
+  {{{./apidocs/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.html#configuration}Javadoc}}.
 
 * Using a Realm for Testing Purposes
 
-  Usually, you are not able to modify Active Directory entries easily (usually admins can), e.g., adding
-  and removing groups. Therefore, you can use default {{{https://tomcat.apache.org/tomcat-8.5-doc/realm-howto.html#UserDatabaseRealm}<<<UserDatabaseRealm>>>}},
+  In most cases you are not able to modify Active Directory entries easily (usually admins can), e.g.,
+  adding and removing groups or their members. Therefore, you can use the {{{https://tomcat.apache.org/tomcat-8.5-doc/realm-howto.html#UserDatabaseRealm}<<<UserDatabaseRealm>>>}},
   fiddle quickly with users and roles to test your application.
 
   Follow the Tomcat documentation and configure a <<<tomcat-users.xml>>> file with the according resource
@@ -130,12 +131,16 @@ Choosing and Using Realms
 
 * Alternative Realm Implementations
 
-  If you are not using the Active Directory as a user repository (e.g. database or another directory
-  server) and can still make use of this library. Extend the Tomcat's default
+  If you are not using Active Directory as a user repository (e.g. database or another directory
+  server) and can still make use of this library. Extend Tomcat's
   {{{https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/realm/RealmBase.html}<<<RealmBase>>>}}
-  class and override the protected method <<<getPrincipal(GSSName, GSSCredential)>>>.
+  class and override any of these methods:
 
-The Next Step
+    * {{{https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/realm/RealmBase.html${esc.hash}getPrincipal(org.ietf.jgss.GSSName,%20org.ietf.jgss.GSSCredential)}<<<protected Principal getPrincipal(GSSName, GSSCredential)>>>}},
+
+    * {{{https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/realm/RealmBase.html${esc.hash}getPrincipal(java.security.cert.X509Certificate)}<<<protected Principal getPrincipal(X509Certificate userCert)>>>}}.
+
+Next Step
 
   You have freed your users from typing usernames and passwords over and over again. Go on and try
   your new {{{./sample-webapp.html}SSO setup}}.

--- a/src/site/apt/sample-webapp.apt.vm
+++ b/src/site/apt/sample-webapp.apt.vm
@@ -30,8 +30,8 @@ Sample Webapp
 
 * Prerequisites
 
-  Create a Servlet 3.1 compatible webapp project with a method of your choice, .e.g., Maven archetype
-  or Eclipse project wizard. Configure the resources (authenticator and realm).
+  Create a Servlet 3.1 compatible webapp project with a method of your choice, e.g., Maven archetype
+  or Eclipse project wizard. Configure the components (authenticator and realm).
 
 * Modifying the Deployment Descriptor (<<<web.xml>>>)
 
@@ -58,7 +58,7 @@ Sample Webapp
     </web-resource-collection>
     <auth-constraint>
       <!-- Every user in the $AD_GROUP can view this specific page -->
-      <!-- Replace $AD_GROUP with a SID of a group or the mapped role name you are actually a member of -->
+      <!-- Replace $AD_GROUP with role format value of a group or the mapped role name you are actually a member of -->
       <role-name>$AD_GROUP</role-name>
     </auth-constraint>
   </security-constraint>
@@ -110,7 +110,7 @@ Hello ${pageContext.request.remoteUser}, you should not see this!
 
 * Verification
 
-  Open every single URL with a properly configured client like IE, Firefox, Chrome or even
+  Open every single URL with a properly configured client like Edge, Firefox, Chrome or even
   cURL on Windows. Your output should be as follows:\
   \
   <<<index.jsp>>>: <<<HTTP/1.1 200 >>>, every user should see a response.\

--- a/src/site/apt/spring-security.apt.vm
+++ b/src/site/apt/spring-security.apt.vm
@@ -28,7 +28,7 @@ Integrating with Spring Security
 
   Once in a while people ask on Stack Overflow how to use this with Spring Security. I was consoling
   people for years for a proper implementation. Finally I have decided not to impelement anything
-  for Spring Security at all. You might ask <<why>>? The answer is rather simple, Spring Security's
+  for Spring Security at all. You might ask <<why>>? The answer is rather simple, The Spring Security
   APIs are so complex and different to those in Tomcat that it would mean to provide a complete
   reimplementation which is a maintenance nightmare. Something I am not willing to do and see no real
   benefit in. Fortunately, the Spring guys were smart enough to think about lazy people like me:

--- a/src/site/apt/user-guide.apt.vm
+++ b/src/site/apt/user-guide.apt.vm
@@ -39,15 +39,15 @@ User Guide
   [[1]] {{{./authenticators.html}Authenticators}}: an authenticator challenges a client to present
         the necessary authentication token to prove its identity.
 
-  [[2]] {{{./realms.html}Realms}}: a realm looks up the roles and other data of a user in the
+  [[2]] {{{./realms.html}Realms}}: a realm looks up the roles and other data of a user in
         Active Directory or any other user repository.
 
   []
 
   Your will need <both> components configured properly to enjoy true SSO in your company network.
 
-  Before using this library, make sure that the main artifact and its dependencies are in the class
-  path of your Tomcat instance, i.e., in <<<$CATALINA_BASE/lib>>> or <<<$CATALINA_HOME/lib>>>.
+  Before using this library, make sure that the main artifact and its dependencies (if not shaded)
+  are in the class path of your Tomcat instance, i.e., in <<<$CATALINA_BASE/lib>>> or <<<$CATALINA_HOME/lib>>>.
 
 * Sample Webapp
 
@@ -60,5 +60,5 @@ User Guide
 * Not using Active Directory but another Kerberos KDC implementation?
 
   If you happen <not> to use Active Directory, but MIT Kerberos or Heimdal as your KDC &#x2013; no
-  problem, the authenticators are not tied to the Active Directory, but simply require a working Kerberos
-  setup. As for the realm, read the chapter on {{{./realms.html#Alternative_Realm_Implementations}alternative realm implementations}}.
+  problem, the authenticators are not tied to Active Directory, but simply require a working Kerberos
+  setup. As for the realm, read the section on {{{./realms.html#Alternative_Realm_Implementations}alternative realm implementations}}.

--- a/src/test/java/net/sf/michaelo/tomcat/asn1/OtherNameAsn1ParserTest.java
+++ b/src/test/java/net/sf/michaelo/tomcat/asn1/OtherNameAsn1ParserTest.java
@@ -1,0 +1,579 @@
+/*
+ * Copyright 2021 Michael Osipov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sf.michaelo.tomcat.asn1;
+
+import java.security.cert.CertificateParsingException;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sf.michaelo.tomcat.realm.asn1.OtherNameAsn1Parser;
+import net.sf.michaelo.tomcat.realm.asn1.OtherNameParseResult;
+
+public class OtherNameAsn1ParserTest {
+
+	@Test(expected = NullPointerException.class)
+	public void testNullUtf8String() throws Exception {
+		OtherNameAsn1Parser.parseUtf8String(null);
+	}
+
+	@Test
+	public void testEmptyUtf8String() {
+		try {
+			OtherNameAsn1Parser.parseUtf8String(new byte[0]);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.equalTo("string type tag not available, buffer is empty"));
+		}
+	}
+
+	@Test
+	public void testNotStartingUtf8String() {
+		byte[] otherName = { (byte) 0x13 };
+
+		try {
+			OtherNameAsn1Parser.parseUtf8String(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("string must start with a UTF8String tag, but starts with"));
+		}
+	}
+
+	@Test
+	public void testTwoByteLengthUtf8String() {
+		byte[] otherName = { (byte) 0x0C, (byte) 0x81, (byte) 0x80 };
+
+		try {
+			OtherNameAsn1Parser.parseUtf8String(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("UTF8String length (128 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testZeroLengthUtf8String() throws Exception {
+		byte[] otherName = { (byte) 0x0C, (byte) 0x00 };
+
+		String utf8String = OtherNameAsn1Parser.parseUtf8String(otherName);
+		MatcherAssert.assertThat(utf8String, CoreMatchers.equalTo(""));
+	}
+
+	@Test
+	public void testUtf8String() throws Exception {
+		byte[] otherName = { (byte) 0x0C, (byte) 0x0A, (byte) 0xD0, (byte) 0x94, (byte) 0xD0, (byte) 0xB6, (byte) 0xD0,
+				(byte) 0xB0, (byte) 0xD0, (byte) 0xB2, (byte) 0xD0, (byte) 0xB0 };
+
+		String utf8String = OtherNameAsn1Parser.parseUtf8String(otherName);
+		MatcherAssert.assertThat(utf8String, CoreMatchers.equalTo("Джава"));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testNullOtherName() throws Exception {
+		OtherNameAsn1Parser.parse(null);
+	}
+
+	@Test
+	public void testEmptyOtherName() {
+		try {
+			OtherNameAsn1Parser.parse(new byte[0]);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.equalTo("otherName type tag not available, buffer is empty"));
+		}
+	}
+
+	@Test
+	public void testNotStartingSequence() {
+		byte[] otherName = { (byte) 0x31 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("otherName must start with a SEQUENCE tag, but starts with "));
+		}
+	}
+
+	@Test
+	public void testNullLength() {
+		byte[] otherName = { (byte) 0x30 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.equalTo("Type length not available, buffer is empty"));
+		}
+	}
+
+	@Test
+	public void testIndefiniteLength() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x80 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("Indefinite type length is not supported"));
+		}
+	}
+
+	@Test
+	public void testMoreThanTwoByteLength() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x83 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.equalTo("Type length above 64 KiB ist not supported"));
+		}
+	}
+
+	@Test
+	public void testTwoByteLength1() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x82 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("Type length bytes (2 B) are larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testTwoByteLength2() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x81, (byte) 0x80 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("SEQUENCE length (128 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testHalfByteLength() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x7F };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("SEQUENCE length (127 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testThreeByteLength1() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x82, (byte) 0xFF, (byte) 0x7F };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("SEQUENCE length (65407 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testThreeByteLength2() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x82, (byte) 0xFF, (byte) 0xFF };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("SEQUENCE length (65535 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testParseNullOid() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x00 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.equalTo("otherName fields not available, buffer is empty"));
+		}
+	}
+
+	@Test
+	public void testParseZeroLengthOid() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x02, (byte) 0x06, (byte) 0x00 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("OID value not available, buffer is empty"));
+		}
+	}
+
+	@Test
+	public void testParseNotStartingOid() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x02, (byte) 0x05, (byte) 0x00 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("OID must start with an OBJECT IDENTIFIER tag, but is"));
+		}
+	}
+
+	@Test
+	public void testParseInvalidOidLength() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x03, (byte) 0x06, (byte) 0x05, (byte) 0x01 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("OBJECT IDENTIFIER length (5 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testParseTruncatedOidLength() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x04 /* here is 1 B missing */, (byte) 0x06, (byte) 0x03, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("OBJECT IDENTIFIER length (3 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testParseNullValue() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x03, (byte) 0x06, (byte) 0x01, (byte) 0x01 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.equalTo("Value type tag not available, buffer is empty"));
+		}
+	}
+
+	@Test
+	public void testParseUniversalTagValue() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x04, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0x0C };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("Value must be explicitly encoded"));
+		}
+	}
+
+	@Test
+	public void testParseConstructedTagValue() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x04, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) (0x0C | 0x10) };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("Value must be explicitly encoded"));
+		}
+	}
+
+	@Test
+	public void testParseContextSpecificTagValue() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x04, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) (0x0C | 0x80) };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("Value must be explicitly encoded"));
+		}
+	}
+
+	@Test
+	public void testParseWrongTagNumberInValue() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x04, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA1 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(), CoreMatchers.startsWith("Value tag number must be 0, but is"));
+		}
+	}
+
+	@Test
+	public void testParseInvalidConstructedValue() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x05, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0,
+				(byte) 0x02 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("Value length (2 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testParseInvalidConstructedValue2() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x05, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x00,
+				(byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("Value not available, buffer is empty"));
+		}
+	}
+
+	@Test
+	public void testParseInvalidConstructedValue3() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x0C, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x06,
+				(byte) 0xA0, (byte) 0x05, (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("Value length (5 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testParseInvalidConstructedValue4() throws Exception {
+		byte[] otherName = { (byte) 0x30, (byte) 0x0C, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x07,
+				(byte) 0xA0, (byte) 0x04, (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
+		Assert.assertArrayEquals(new byte[] { 0x01 }, result.getTypeId());
+		Assert.assertArrayEquals(new byte[] { (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E' }, result.getValue());
+	}
+
+	@Test
+	public void testParseInvalidConstructedValue5() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x0C, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x07,
+				(byte) 0xA0, (byte) 0x00, (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("Value not available, buffer is empty"));
+		}
+	}
+
+	@Test
+	public void testParseOtherName() throws Exception {
+		byte[] otherName = { (byte) 0x30, (byte) 0x0A, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x05,
+				(byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
+		Assert.assertArrayEquals(new byte[] { 0x01 }, result.getTypeId());
+		Assert.assertArrayEquals(new byte[] { (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' },
+				result.getValue());
+	}
+
+	@Test
+	public void testParseConstructedTagValueJDK6776681() throws Exception {
+		byte[] otherName = { (byte) 0x30, (byte) 0x0C, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x07,
+				(byte) (0xC | 0x10), (byte) 0x05, (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
+		Assert.assertArrayEquals(new byte[] { 0x01 }, result.getTypeId());
+		Assert.assertArrayEquals(new byte[] { (byte) (0xC | 0x10), (byte) 0x05, (byte) 0x0C, (byte) 0x03, (byte) 'Y',
+				(byte) 'E', (byte) 'S' }, result.getValue());
+	}
+
+	@Test
+	public void testParseContextSpecificTagValueJDK6776681() throws Exception {
+		byte[] otherName = { (byte) 0x30, (byte) 0x0C, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x07,
+				(byte) (0xC | 0x80), (byte) 0x05, (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
+		Assert.assertArrayEquals(new byte[] { 0x01 }, result.getTypeId());
+		Assert.assertArrayEquals(new byte[] { (byte) (0xC | 0x80), (byte) 0x05, (byte) 0x0C, (byte) 0x03, (byte) 'Y',
+				(byte) 'E', (byte) 'S' }, result.getValue());
+	}
+
+	@Test
+	public void testParseWrongTagNumberValueJDK6776681() throws Exception {
+		byte[] otherName = { (byte) 0x30, (byte) 0x0C, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x07,
+				(byte) 0xA1, (byte) 0x05, (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
+		Assert.assertArrayEquals(new byte[] { 0x01 }, result.getTypeId());
+		Assert.assertArrayEquals(
+				new byte[] { (byte) 0xA1, (byte) 0x05, (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' },
+				result.getValue());
+	}
+
+	@Test
+	public void testParseInvalidConstructedValueJDK6776681() {
+		byte[] otherName = { (byte) 0x30, (byte) 0x07, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x02,
+				(byte) 0xA0, (byte) 0x02 };
+
+		try {
+			OtherNameAsn1Parser.parse(otherName);
+			Assert.fail("Exception expected");
+		} catch (CertificateParsingException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					CoreMatchers.startsWith("Value length (2 B) is larger than the buffer offers"));
+		}
+	}
+
+	@Test
+	public void testParseOtherNameJDK6776681() throws Exception {
+		byte[] otherName = { (byte) 0x30, (byte) 0x0C, (byte) 0x06, (byte) 0x01, (byte) 0x01, (byte) 0xA0, (byte) 0x07,
+				(byte) 0xA0, (byte) 0x05, (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' };
+
+		OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
+		Assert.assertArrayEquals(new byte[] { 0x01 }, result.getTypeId());
+		Assert.assertArrayEquals(new byte[] { (byte) 0x0C, (byte) 0x03, (byte) 'Y', (byte) 'E', (byte) 'S' },
+				result.getValue());
+	}
+
+	@Test
+	public void testParseOtherNameLongSequence() throws Exception {
+		byte[] otherName = { (byte) 0x30, (byte) 0x82, (byte) 0x01, (byte) 0x01, (byte) 0x06, (byte) 0x64, (byte) 0x02,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x02, (byte) 0xA0, (byte) 0x81, (byte) 0x98, (byte) 0xA0, (byte) 0x81,
+				(byte) 0x95, (byte) 0x0C, (byte) 0x81, (byte) 0x92, (byte) 'Y', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'S' };
+
+		OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
+		byte[] typeId = result.getTypeId();
+		Assert.assertEquals(100, typeId.length);
+		Assert.assertEquals(2, typeId[0]);
+		Assert.assertEquals(2, typeId[typeId.length - 1]);
+		byte[] value = result.getValue();
+		Assert.assertEquals(149, value.length);
+		String str = OtherNameAsn1Parser.parseUtf8String(value);
+		Assert.assertEquals(
+				"YEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEES",
+				str);
+	}
+
+	@Test
+	public void testParseOtherNameLongSequenceJDK6776681() throws Exception {
+		byte[] otherName = { (byte) 0x30, (byte) 0x81, (byte) 0xFE, (byte) 0x06, (byte) 0x64, (byte) 0x02, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+				(byte) 0x01, (byte) 0x02, (byte) 0xA0, (byte) 0x81, (byte) 0x95, (byte) 0x0C, (byte) 0x81, (byte) 0x92,
+				(byte) 'Y', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E', (byte) 'E',
+				(byte) 'E', (byte) 'S' };
+
+		OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
+		byte[] typeId = result.getTypeId();
+		Assert.assertEquals(100, typeId.length);
+		Assert.assertEquals(2, typeId[0]);
+		Assert.assertEquals(2, typeId[typeId.length - 1]);
+		byte[] value = result.getValue();
+		Assert.assertEquals(149, value.length);
+		String str = OtherNameAsn1Parser.parseUtf8String(value);
+		Assert.assertEquals(
+				"YEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEES",
+				str);
+	}
+
+}


### PR DESCRIPTION
The PR contains all necessary code to authenticate the user through Tomcat's `SSLAuthenticator`, but use the given `ActiveDirectoryRealm`.