### PR TITLE
Use Tomcat's ASN.1 parser for UTF8Strings

### DIFF
--- a/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.java
+++ b/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.java
@@ -64,6 +64,7 @@ import org.apache.catalina.Server;
 import org.apache.catalina.realm.CombinedRealm;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.naming.ContextBindings;
+import org.apache.tomcat.util.buf.Asn1Parser;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.apache.tomcat.util.collections.SynchronizedStack;
 import org.ietf.jgss.GSSCredential;
@@ -391,7 +392,8 @@ public class ActiveDirectoryRealm extends ActiveDirectoryRealmBase {
 					try {
 						OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
 						if (Arrays.equals(result.getTypeId(), MS_UPN_OID_BYTES)) {
-							String upn = OtherNameAsn1Parser.parseUtf8String(result.getValue());
+							Asn1Parser parser = new Asn1Parser(result.getValue());
+							String upn = parser.parseUTF8String();
 							if (logger.isDebugEnabled())
 								logger.debug(sm.getString("activeDirectoryRealm.msUpnExtracted", upn, dn));
 

--- a/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameAsn1Parser.java
+++ b/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameAsn1Parser.java
@@ -31,8 +31,6 @@ import org.apache.tomcat.util.buf.Asn1Parser;
  */
 public class OtherNameAsn1Parser {
 
-	private static byte UTF8STRING_TAG = 0x0C;
-
 	private OtherNameAsn1Parser() {
 	}
 
@@ -65,31 +63,6 @@ public class OtherNameAsn1Parser {
 			value = parser.parseAttributeAsBytes(0);
 
 		return new OtherNameParseResult(typeId, value);
-	}
-
-	/**
-	 * Parses a DER-encoded ASN.1 {@code UTF8String} to a Java string:
-	 *
-	 * @param str a DER-encoded byte array
-	 * @return the converted Java string
-	 * @throws NullPointerException     if {@code str} is {@code null}
-	 * @throws IllegalArgumentException if {@code str} is empty or if the
-	 *                                  DER-encoded byte array does not comply with
-	 *                                  ASN.1 DER encoding rules
-	 */
-	public static String parseUtf8String(byte[] str) {
-		Objects.requireNonNull(str, "str cannot be null");
-		if (str.length == 0)
-			throw new IllegalArgumentException("str cannot be empty");
-
-		Asn1Parser parser = new Asn1Parser(str);
-
-		parser.parseTag(UTF8STRING_TAG);
-		int len = parser.parseLength();
-		byte[] value = new byte[len];
-		parser.parseBytes(value);
-
-		return new String(value, StandardCharsets.UTF_8);
 	}
 
 }

--- a/tomcat101/src/test/java/net/sf/michaelo/tomcat/asn1/OtherNameAsn1ParserTest.java
+++ b/tomcat101/src/test/java/net/sf/michaelo/tomcat/asn1/OtherNameAsn1ParserTest.java
@@ -15,6 +15,7 @@
  */
 package net.sf.michaelo.tomcat.asn1;
 
+import org.apache.tomcat.util.buf.Asn1Parser;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -24,53 +25,6 @@ import net.sf.michaelo.tomcat.realm.asn1.OtherNameAsn1Parser;
 import net.sf.michaelo.tomcat.realm.asn1.OtherNameParseResult;
 
 public class OtherNameAsn1ParserTest {
-
-	@Test(expected = NullPointerException.class)
-	public void testNullUtf8String() throws Exception {
-		OtherNameAsn1Parser.parseUtf8String(null);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testEmptyUtf8String() {
-		OtherNameAsn1Parser.parseUtf8String(new byte[0]);
-	}
-
-	@Test
-	public void testNotStartingUtf8String() {
-		byte[] otherName = { (byte) 0x13 };
-
-		try {
-			OtherNameAsn1Parser.parseUtf8String(otherName);
-			Assert.fail("Exception expected");
-		} catch (IllegalArgumentException e) {
-			MatcherAssert.assertThat(e.getMessage(),
-					CoreMatchers.equalTo("Expected to find value [12] but found value [19]"));
-		}
-	}
-
-	@Test(expected = ArrayIndexOutOfBoundsException.class)
-	public void testTwoByteLengthUtf8String() {
-		byte[] otherName = { (byte) 0x0C, (byte) 0x81, (byte) 0x80 };
-
-		OtherNameAsn1Parser.parseUtf8String(otherName);
-	}
-
-	@Test
-	public void testZeroLengthUtf8String() throws Exception {
-		byte[] otherName = { (byte) 0x0C, (byte) 0x00 };
-
-		String utf8String = OtherNameAsn1Parser.parseUtf8String(otherName);
-		MatcherAssert.assertThat(utf8String, CoreMatchers.equalTo(""));
-	}
-
-	@Test
-	public void testUtf8String() throws Exception {
-		byte[] otherName = { (byte) 0x0C, (byte) 0x0A, (byte) 0xD0, (byte) 0x94, (byte) 0xD0, (byte) 0xB6, (byte) 0xD0,
-				(byte) 0xB0, (byte) 0xD0, (byte) 0xB2, (byte) 0xD0, (byte) 0xB0 };
-
-		String utf8String = OtherNameAsn1Parser.parseUtf8String(otherName);
-		MatcherAssert.assertThat(utf8String, CoreMatchers.equalTo("Джава"));
-	}
 
 	@Test(expected = NullPointerException.class)
 	public void testNullOtherName() throws Exception {
@@ -432,7 +386,8 @@ public class OtherNameAsn1ParserTest {
 		Assert.assertEquals(2, typeId[typeId.length - 1]);
 		byte[] value = result.getValue();
 		Assert.assertEquals(149, value.length);
-		String str = OtherNameAsn1Parser.parseUtf8String(value);
+		Asn1Parser parser = new Asn1Parser(value);
+		String str = parser.parseUTF8String();
 		Assert.assertEquals(
 				"YEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEES",
 				str);
@@ -481,7 +436,8 @@ public class OtherNameAsn1ParserTest {
 		Assert.assertEquals(2, typeId[typeId.length - 1]);
 		byte[] value = result.getValue();
 		Assert.assertEquals(149, value.length);
-		String str = OtherNameAsn1Parser.parseUtf8String(value);
+		Asn1Parser parser = new Asn1Parser(value);
+		String str = parser.parseUTF8String();
 		Assert.assertEquals(
 				"YEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEES",
 				str);

--- a/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.java
+++ b/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealm.java
@@ -64,6 +64,7 @@ import org.apache.catalina.Server;
 import org.apache.catalina.realm.CombinedRealm;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.naming.ContextBindings;
+import org.apache.tomcat.util.buf.Asn1Parser;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.apache.tomcat.util.collections.SynchronizedStack;
 import org.ietf.jgss.GSSCredential;
@@ -391,7 +392,8 @@ public class ActiveDirectoryRealm extends ActiveDirectoryRealmBase {
 					try {
 						OtherNameParseResult result = OtherNameAsn1Parser.parse(otherName);
 						if (Arrays.equals(result.getTypeId(), MS_UPN_OID_BYTES)) {
-							String upn = OtherNameAsn1Parser.parseUtf8String(result.getValue());
+							Asn1Parser parser = new Asn1Parser(result.getValue());
+							String upn = parser.parseUTF8String();
 							if (logger.isDebugEnabled())
 								logger.debug(sm.getString("activeDirectoryRealm.msUpnExtracted", upn, dn));
 

--- a/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameAsn1Parser.java
+++ b/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/asn1/OtherNameAsn1Parser.java
@@ -31,8 +31,6 @@ import org.apache.tomcat.util.buf.Asn1Parser;
  */
 public class OtherNameAsn1Parser {
 
-	private static byte UTF8STRING_TAG = 0x0C;
-
 	private OtherNameAsn1Parser() {
 	}
 
@@ -65,31 +63,6 @@ public class OtherNameAsn1Parser {
 			value = parser.parseAttributeAsBytes(0);
 
 		return new OtherNameParseResult(typeId, value);
-	}
-
-	/**
-	 * Parses a DER-encoded ASN.1 {@code UTF8String} to a Java string:
-	 *
-	 * @param str a DER-encoded byte array
-	 * @return the converted Java string
-	 * @throws NullPointerException     if {@code str} is {@code null}
-	 * @throws IllegalArgumentException if {@code str} is empty or if the
-	 *                                  DER-encoded byte array does not comply with
-	 *                                  ASN.1 DER encoding rules
-	 */
-	public static String parseUtf8String(byte[] str) {
-		Objects.requireNonNull(str, "str cannot be null");
-		if (str.length == 0)
-			throw new IllegalArgumentException("str cannot be empty");
-
-		Asn1Parser parser = new Asn1Parser(str);
-
-		parser.parseTag(UTF8STRING_TAG);
-		int len = parser.parseLength();
-		byte[] value = new byte[len];
-		parser.parseBytes(value);
-
-		return new String(value, StandardCharsets.UTF_8);
 	}
 
 }

--- a/tomcat90/src/test/java/net/sf/michaelo/tomcat/asn1/OtherNameAsn1ParserTest.java
+++ b/tomcat90/src/test/java/net/sf/michaelo/tomcat/asn1/OtherNameAsn1ParserTest.java
@@ -15,6 +15,7 @@
  */
 package net.sf.michaelo.tomcat.asn1;
 
+import org.apache.tomcat.util.buf.Asn1Parser;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -24,53 +25,6 @@ import net.sf.michaelo.tomcat.realm.asn1.OtherNameAsn1Parser;
 import net.sf.michaelo.tomcat.realm.asn1.OtherNameParseResult;
 
 public class OtherNameAsn1ParserTest {
-
-	@Test(expected = NullPointerException.class)
-	public void testNullUtf8String() throws Exception {
-		OtherNameAsn1Parser.parseUtf8String(null);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testEmptyUtf8String() {
-		OtherNameAsn1Parser.parseUtf8String(new byte[0]);
-	}
-
-	@Test
-	public void testNotStartingUtf8String() {
-		byte[] otherName = { (byte) 0x13 };
-
-		try {
-			OtherNameAsn1Parser.parseUtf8String(otherName);
-			Assert.fail("Exception expected");
-		} catch (IllegalArgumentException e) {
-			MatcherAssert.assertThat(e.getMessage(),
-					CoreMatchers.equalTo("Expected to find value [12] but found value [19]"));
-		}
-	}
-
-	@Test(expected = ArrayIndexOutOfBoundsException.class)
-	public void testTwoByteLengthUtf8String() {
-		byte[] otherName = { (byte) 0x0C, (byte) 0x81, (byte) 0x80 };
-
-		OtherNameAsn1Parser.parseUtf8String(otherName);
-	}
-
-	@Test
-	public void testZeroLengthUtf8String() throws Exception {
-		byte[] otherName = { (byte) 0x0C, (byte) 0x00 };
-
-		String utf8String = OtherNameAsn1Parser.parseUtf8String(otherName);
-		MatcherAssert.assertThat(utf8String, CoreMatchers.equalTo(""));
-	}
-
-	@Test
-	public void testUtf8String() throws Exception {
-		byte[] otherName = { (byte) 0x0C, (byte) 0x0A, (byte) 0xD0, (byte) 0x94, (byte) 0xD0, (byte) 0xB6, (byte) 0xD0,
-				(byte) 0xB0, (byte) 0xD0, (byte) 0xB2, (byte) 0xD0, (byte) 0xB0 };
-
-		String utf8String = OtherNameAsn1Parser.parseUtf8String(otherName);
-		MatcherAssert.assertThat(utf8String, CoreMatchers.equalTo("Джава"));
-	}
 
 	@Test(expected = NullPointerException.class)
 	public void testNullOtherName() throws Exception {
@@ -432,7 +386,8 @@ public class OtherNameAsn1ParserTest {
 		Assert.assertEquals(2, typeId[typeId.length - 1]);
 		byte[] value = result.getValue();
 		Assert.assertEquals(149, value.length);
-		String str = OtherNameAsn1Parser.parseUtf8String(value);
+		Asn1Parser parser = new Asn1Parser(value);
+		String str = parser.parseUTF8String();
 		Assert.assertEquals(
 				"YEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEES",
 				str);
@@ -481,7 +436,8 @@ public class OtherNameAsn1ParserTest {
 		Assert.assertEquals(2, typeId[typeId.length - 1]);
 		byte[] value = result.getValue();
 		Assert.assertEquals(149, value.length);
-		String str = OtherNameAsn1Parser.parseUtf8String(value);
+		Asn1Parser parser = new Asn1Parser(value);
+		String str = parser.parseUTF8String();
 		Assert.assertEquals(
 				"YEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEES",
 				str);


### PR DESCRIPTION
With 4b815e04f3850cb1a6b897290ddef2c89bcb3d5e Tomcat 10.1 and 9.0 can now parse UTF8Strings directly. Drop our implementation.