### PR TITLE
Introduce a Krb5AuthzDataDumpingActiveDirectoryRealm

### DIFF
--- a/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealmBase.java
+++ b/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealmBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013–2023 Michael Osipov
+ * Copyright 2013–2024 Michael Osipov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSName;
 
 /**
- * Base realm which is able to retrieve principals from {@link GSSName GSS names}, fully
- * established {@link GSSContext GSS contexts} or {@link X509Certificate TLS client certificates}.
+ * Base Active Directory realm which is able to retrieve principals for {@link GSSName GSS names},
+ * fully established {@link GSSContext security contexts} or {@link X509Certificate TLS client certificates}.
  */
 public abstract class ActiveDirectoryRealmBase extends RealmBase {
 

--- a/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.java
+++ b/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 Michael Osipov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sf.michaelo.tomcat.realm;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.Principal;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Set;
+
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSName;
+
+import com.sun.security.jgss.AuthorizationDataEntry;
+import com.sun.security.jgss.ExtendedGSSContext;
+import com.sun.security.jgss.InquireType;
+
+/**
+ * A realm which extracts and dumps Kerberos {@code AuthorizationData}, but delegates the actual
+ * work to {@link ActiveDirectoryRealm#getPrincipal(GSSName, GSSCredential)}.
+ * <p>
+ * This realm requires your JVM to provide an {@link ExtendedGSSContext} implementation. It will use
+ * {@link InquireType#KRB5_GET_AUTHZ_DATA} to extract {@code AuthorizationData} according to RFC 4120,
+ * section 5.2.6 from an established security context, dump to
+ * <code>{catalina.base}/work/KRB5_AUTHZ_DATA/{gssName}/{yyyyMMdd'T'HHmmss.SSS}{#n?}</code> and
+ * continue as described.
+ */
+public class Krb5AuthzDataDumpingActiveDirectoryRealm extends ActiveDirectoryRealm {
+
+	private static final DateTimeFormatter TS_FORMAT = DateTimeFormatter
+			.ofPattern("yyyyMMdd'T'HHmmss.SSS").withZone(ZoneId.systemDefault());
+
+	protected Principal getPrincipal(GSSName gssName, GSSCredential gssCredential,
+			GSSContext gssContext) {
+		if (gssContext instanceof ExtendedGSSContext) {
+			ExtendedGSSContext extGssContext = (ExtendedGSSContext) gssContext;
+
+			AuthorizationDataEntry[] adEntries = null;
+			try {
+				adEntries = (AuthorizationDataEntry[]) extGssContext
+						.inquireSecContext(InquireType.KRB5_GET_AUTHZ_DATA);
+
+			} catch (GSSException e) {
+				logger.warn(sm.getString("krb5AuthzDataRealmBase.inquireSecurityContextFailed"), e);
+			}
+
+			if (adEntries == null) {
+				if (logger.isDebugEnabled())
+					logger.debug(sm.getString("krb5AuthzDataRealmBase.noDataProvided", gssName));
+				return null;
+			}
+
+			File catalinaBase = getServer().getCatalinaBase();
+			Path workDir = catalinaBase.toPath().resolve("work");
+			Instant id = Instant.now();
+
+			Path dumpDir = workDir.resolve("KRB5_AUTHZ_DATA").resolve(gssName.toString());
+			try {
+				Path dumpFile = createDumpFile(dumpDir, id);
+				try (PrintWriter w = new PrintWriter(Files.newBufferedWriter(dumpFile))) {
+					for (AuthorizationDataEntry adEntry : adEntries) {
+						w.printf("%d %s%n", adEntry.getType(),
+								Base64.getEncoder().encodeToString(adEntry.getData()));
+					}
+				}
+			} catch (IOException e) {
+				logger.warn(sm.getString(
+						"krb5AuthzDataDumpingActiveDirectoryRealm.dumpingKrb5AuthzDataFailed",
+						gssName), e);
+			}
+		} else {
+			logger.error(sm.getString("krb5AuthzDataRealmBase.incompatibleSecurityContextType"));
+		}
+
+		return getPrincipal(gssName, gssCredential);
+	}
+
+	private Path createDumpFile(Path dumpDir, Instant id) throws IOException {
+		Files.createDirectories(dumpDir);
+		String formattedTimestamp = TS_FORMAT.format(id);
+		Path dumpFile = dumpDir.resolve(formattedTimestamp);
+		int i = 2;
+		while (Files.exists(dumpFile)) {
+			dumpFile = dumpDir.resolve(formattedTimestamp + "#" + i++);
+		}
+		if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+			Set<PosixFilePermission> ownerWritable = PosixFilePermissions.fromString("rw-------");
+			FileAttribute<?> permissions = PosixFilePermissions.asFileAttribute(ownerWritable);
+			Files.createFile(dumpFile, permissions);
+		}
+		return dumpFile;
+	}
+
+}

--- a/tomcat101/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
+++ b/tomcat101/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
@@ -56,3 +56,9 @@ activeDirectoryRealm.msUpnExtracted=Successfully extracted MS UPN ''{0}'' from c
 activeDirectoryRealm.canonicalizingUser=Canonicalizing user from string name type ''{0}'' to ''{1}''
 activeDirectoryRealm.canonicalizeUserFailed=Failed to canonicalize user ''{0}''
 activeDirectoryRealm.userCanonicalized=Successfully canonicalized user to ''{0}''
+
+krb5AuthzDataRealmBase.incompatibleSecurityContextType=Security context is not of type ''ExtendedGSSContext''
+krb5AuthzDataRealmBase.inquireSecurityContextFailed=Failed to inquire KRB5_AUTHZ_DATA from security context
+krb5AuthzDataRealmBase.noDataProvided=No KRB5_AUTHZ_DATA has been provided by the security context for user ''{0}''
+
+krb5AuthzDataDumpingActiveDirectoryRealm.dumpingKrb5AuthzDataFailed=Failed to dump KRB5_AUTHZ_DATA for user ''{0}''

--- a/tomcat90/pom.xml
+++ b/tomcat90/pom.xml
@@ -146,6 +146,12 @@
 						<link>https://tomcat.apache.org/tomcat-9.0-doc/jaspicapi</link>
 						<link>https://michael-o.github.io/dirctxsrc/apidocs/</link>
 					</links>
+					<offlineLinks>
+						<offlineLink>
+							<url>https://docs.oracle.com/javase/8/docs/jre/api/security/jgss/spec/</url>
+							<location>${project.basedir}/src/apidocs/api.security.jgss</location>
+						</offlineLink>
+					</offlineLinks>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -163,6 +169,12 @@
 						<link>https://tomcat.apache.org/tomcat-9.0-doc/jaspicapi</link>
 						<link>https://michael-o.github.io/dirctxsrc/apidocs/</link>
 					</links>
+					<offlineLinks>
+						<offlineLink>
+							<url>https://docs.oracle.com/javase/8/docs/jre/api/security/jgss/spec/</url>
+							<location>${project.basedir}/src/apidocs/api.security.jgss</location>
+						</offlineLink>
+					</offlineLinks>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/tomcat90/src/apidocs/api.security.jgss/package-list
+++ b/tomcat90/src/apidocs/api.security.jgss/package-list
@@ -1,0 +1,1 @@
+com.sun.security.jgss

--- a/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealmBase.java
+++ b/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/ActiveDirectoryRealmBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013–2021 Michael Osipov
+ * Copyright 2013–2024 Michael Osipov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSName;
 
 /**
- * Base realm which is able to retrieve principals from {@link GSSName GSS names}, fully
- * established {@link GSSContext GSS contexts} or {@link X509Certificate TLS client certificates}.
+ * Base Active Directory realm which is able to retrieve principals for {@link GSSName GSS names},
+ * fully established {@link GSSContext security contexts} or {@link X509Certificate TLS client certificates}.
  */
 public abstract class ActiveDirectoryRealmBase extends RealmBase {
 

--- a/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.java
+++ b/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 Michael Osipov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sf.michaelo.tomcat.realm;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.Principal;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Set;
+
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSName;
+
+import com.sun.security.jgss.AuthorizationDataEntry;
+import com.sun.security.jgss.ExtendedGSSContext;
+import com.sun.security.jgss.InquireType;
+
+/**
+ * A realm which extracts and dumps Kerberos {@code AuthorizationData}, but delegates the actual
+ * work to {@link ActiveDirectoryRealm#getPrincipal(GSSName, GSSCredential)}.
+ * <p>
+ * This realm requires your JVM to provide an {@link ExtendedGSSContext} implementation. It will use
+ * {@link InquireType#KRB5_GET_AUTHZ_DATA} to extract {@code AuthorizationData} according to RFC 4120,
+ * section 5.2.6 from an established security context, dump to
+ * <code>{catalina.base}/work/KRB5_AUTHZ_DATA/{gssName}/{yyyyMMdd'T'HHmmss.SSS}{#n?}</code> and
+ * continue as described.
+ */
+public class Krb5AuthzDataDumpingActiveDirectoryRealm extends ActiveDirectoryRealm {
+
+	private static final DateTimeFormatter TS_FORMAT = DateTimeFormatter
+			.ofPattern("yyyyMMdd'T'HHmmss.SSS").withZone(ZoneId.systemDefault());
+
+	protected Principal getPrincipal(GSSName gssName, GSSCredential gssCredential,
+			GSSContext gssContext) {
+		if (gssContext instanceof ExtendedGSSContext) {
+			ExtendedGSSContext extGssContext = (ExtendedGSSContext) gssContext;
+
+			AuthorizationDataEntry[] adEntries = null;
+			try {
+				adEntries = (AuthorizationDataEntry[]) extGssContext
+						.inquireSecContext(InquireType.KRB5_GET_AUTHZ_DATA);
+
+			} catch (GSSException e) {
+				logger.warn(sm.getString("krb5AuthzDataRealmBase.inquireSecurityContextFailed"), e);
+			}
+
+			if (adEntries == null) {
+				if (logger.isDebugEnabled())
+					logger.debug(sm.getString("krb5AuthzDataRealmBase.noDataProvided", gssName));
+				return null;
+			}
+
+			File catalinaBase = getServer().getCatalinaBase();
+			Path workDir = catalinaBase.toPath().resolve("work");
+			Instant id = Instant.now();
+
+			Path dumpDir = workDir.resolve("KRB5_AUTHZ_DATA").resolve(gssName.toString());
+			try {
+				Path dumpFile = createDumpFile(dumpDir, id);
+				try (PrintWriter w = new PrintWriter(Files.newBufferedWriter(dumpFile))) {
+					for (AuthorizationDataEntry adEntry : adEntries) {
+						w.printf("%d %s%n", adEntry.getType(),
+								Base64.getEncoder().encodeToString(adEntry.getData()));
+					}
+				}
+			} catch (IOException e) {
+				logger.warn(sm.getString(
+						"krb5AuthzDataDumpingActiveDirectoryRealm.dumpingKrb5AuthzDataFailed",
+						gssName), e);
+			}
+		} else {
+			logger.error(sm.getString("krb5AuthzDataRealmBase.incompatibleSecurityContextType"));
+		}
+
+		return getPrincipal(gssName, gssCredential);
+	}
+
+	private Path createDumpFile(Path dumpDir, Instant id) throws IOException {
+		Files.createDirectories(dumpDir);
+		String formattedTimestamp = TS_FORMAT.format(id);
+		Path dumpFile = dumpDir.resolve(formattedTimestamp);
+		int i = 2;
+		while (Files.exists(dumpFile)) {
+			dumpFile = dumpDir.resolve(formattedTimestamp + "#" + i++);
+		}
+		if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+			Set<PosixFilePermission> ownerWritable = PosixFilePermissions.fromString("rw-------");
+			FileAttribute<?> permissions = PosixFilePermissions.asFileAttribute(ownerWritable);
+			Files.createFile(dumpFile, permissions);
+		}
+		return dumpFile;
+	}
+
+}

--- a/tomcat90/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
+++ b/tomcat90/src/main/resources/net/sf/michaelo/tomcat/realm/LocalStrings.properties
@@ -56,3 +56,9 @@ activeDirectoryRealm.msUpnExtracted=Successfully extracted MS UPN ''{0}'' from c
 activeDirectoryRealm.canonicalizingUser=Canonicalizing user from string name type ''{0}'' to ''{1}''
 activeDirectoryRealm.canonicalizeUserFailed=Failed to canonicalize user ''{0}''
 activeDirectoryRealm.userCanonicalized=Successfully canonicalized user to ''{0}''
+
+krb5AuthzDataRealmBase.incompatibleSecurityContextType=Security context is not of type ''ExtendedGSSContext''
+krb5AuthzDataRealmBase.inquireSecurityContextFailed=Failed to inquire KRB5_AUTHZ_DATA from security context
+krb5AuthzDataRealmBase.noDataProvided=No KRB5_AUTHZ_DATA has been provided by the security context for user ''{0}''
+
+krb5AuthzDataDumpingActiveDirectoryRealm.dumpingKrb5AuthzDataFailed=Failed to dump KRB5_AUTHZ_DATA for user ''{0}''


### PR DESCRIPTION
This realm is intended for testing and analysis purposes only. Collect the data, dump them, delegate to the actual ActiveDirectoryRealm and then analyze it offline.