### PR TITLE
Make Krb5AuthzDataDumpingActiveDirectoryRealm fallthrough only

### DIFF
--- a/src/site/apt/realms.apt.vm
+++ b/src/site/apt/realms.apt.vm
@@ -119,7 +119,7 @@ Choosing and Using Realms
   It requires a single-step setup.
 
     [Note] Unsure about this realm? Use the {{{./tomcat90-authnz-spnego-ad/apidocs/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.html}<<<Krb5AuthzDataDumpingActiveDirectoryRealm>>>}}
-           (which wraps the <<<ActiveDirectoryRealm>>>) to collect authorization data and analyze it with the {{{./tomcat90-authnz-spnego-ad/apidocs/net/sf/michaelo/tomcat/pac/Krb5AuthzDataDumpPrinter.html}<<<Krb5AuthzDataDumpPrinter>>>}}.
+           to collect authorization data and analyze it with the {{{./tomcat90-authnz-spnego-ad/apidocs/net/sf/michaelo/tomcat/pac/Krb5AuthzDataDumpPrinter.html}<<<Krb5AuthzDataDumpPrinter>>>}}.
 
 ** Configuring the Realm
 

--- a/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.java
+++ b/tomcat101/src/main/java/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.java
@@ -43,8 +43,9 @@ import com.sun.security.jgss.InquireType;
 import net.sf.michaelo.tomcat.pac.Krb5AuthzDataDumpPrinter;
 
 /**
- * A realm which extracts and dumps Kerberos {@code AuthorizationData}, but delegates the actual
- * work to {@link ActiveDirectoryRealm#getPrincipal(GSSName, GSSCredential)}.
+ * A realm which extracts and dumps Kerberos {@code AuthorizationData} and always returns a {@code null}.
+ * Use the {@link CombinedRealm} to authenticate against this one first and then against the actual
+ * one next.
  * <p>
  * This realm requires your JVM to provide an {@link ExtendedGSSContext} implementation. It will use
  * {@link InquireType#KRB5_GET_AUTHZ_DATA} to extract {@code AuthorizationData} according to RFC 4120,
@@ -55,7 +56,7 @@ import net.sf.michaelo.tomcat.pac.Krb5AuthzDataDumpPrinter;
  * <strong>Note</strong>: Use this realm for testing/analysis purposes only along with the
  * {@link Krb5AuthzDataDumpPrinter}.
  */
-public class Krb5AuthzDataDumpingActiveDirectoryRealm extends ActiveDirectoryRealm {
+public class Krb5AuthzDataDumpingActiveDirectoryRealm extends ActiveDirectoryRealmBase {
 
 	private static final DateTimeFormatter TS_FORMAT = DateTimeFormatter
 			.ofPattern("yyyyMMdd'T'HHmmss.SSS").withZone(ZoneId.systemDefault());
@@ -102,7 +103,7 @@ public class Krb5AuthzDataDumpingActiveDirectoryRealm extends ActiveDirectoryRea
 			logger.error(sm.getString("krb5AuthzDataRealmBase.incompatibleSecurityContextType"));
 		}
 
-		return getPrincipal(gssName, gssCredential);
+		return null;
 	}
 
 	private Path createDumpFile(Path dumpDir, Instant id) throws IOException {

--- a/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.java
+++ b/tomcat90/src/main/java/net/sf/michaelo/tomcat/realm/Krb5AuthzDataDumpingActiveDirectoryRealm.java
@@ -43,8 +43,9 @@ import com.sun.security.jgss.InquireType;
 import net.sf.michaelo.tomcat.pac.Krb5AuthzDataDumpPrinter;
 
 /**
- * A realm which extracts and dumps Kerberos {@code AuthorizationData}, but delegates the actual
- * work to {@link ActiveDirectoryRealm#getPrincipal(GSSName, GSSCredential)}.
+ * A realm which extracts and dumps Kerberos {@code AuthorizationData} and always returns a {@code null}.
+ * Use the {@link CombinedRealm} to authenticate against this one first and then against the actual
+ * one next.
  * <p>
  * This realm requires your JVM to provide an {@link ExtendedGSSContext} implementation. It will use
  * {@link InquireType#KRB5_GET_AUTHZ_DATA} to extract {@code AuthorizationData} according to RFC 4120,
@@ -55,7 +56,7 @@ import net.sf.michaelo.tomcat.pac.Krb5AuthzDataDumpPrinter;
  * <strong>Note</strong>: Use this realm for testing/analysis purposes only along with the
  * {@link Krb5AuthzDataDumpPrinter}.
  */
-public class Krb5AuthzDataDumpingActiveDirectoryRealm extends ActiveDirectoryRealm {
+public class Krb5AuthzDataDumpingActiveDirectoryRealm extends ActiveDirectoryRealmBase {
 
 	private static final DateTimeFormatter TS_FORMAT = DateTimeFormatter
 			.ofPattern("yyyyMMdd'T'HHmmss.SSS").withZone(ZoneId.systemDefault());
@@ -102,7 +103,7 @@ public class Krb5AuthzDataDumpingActiveDirectoryRealm extends ActiveDirectoryRea
 			logger.error(sm.getString("krb5AuthzDataRealmBase.incompatibleSecurityContextType"));
 		}
 
-		return getPrincipal(gssName, gssCredential);
+		return null;
 	}
 
 	private Path createDumpFile(Path dumpDir, Instant id) throws IOException {


### PR DESCRIPTION
Instead of coupling this realm to the ActiveDirectoryRealm, it will now return always a null. Thus, it can be used with a CombinedRealm nested with the actual realm (any).

This fixes #27